### PR TITLE
QR check update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,34 @@ This is an updated fork of [Inline QRCode](http://techlister.com/plugins-2/qrcod
 ## Features
 ### Old
 * QRCodes are generated and cached for every new short url
-* New QRCode is generated when the user edits the short url
-* Cached QRCode is deleted when the user deletes an url
-* Displays QRCode within the sharebox, whenever the sharebox is displayed
-* ~~QRCodes generated at 165 x 165 pixels.~~ __updated__
-* Codes are generated from standalone php QRCode library from Sourceforge.net
+* A new QRCode is generated when a short url is edited
+* Cached QRCodes are deleted when its corresponding short url is deleted
+* QRCodes are displayed within the sharebox whenever the sharebox is displayed
+* QRCodes are generated for pre-existing shorturls when sharebox is displayed
+* Codes are generated from a standalone php based QRCode library
   * No calls to google!
-* QRCodes can be generated for pre-existing shorturls by visiting stats page
 
 ### New
-* All options are available in the admin interface, no file editing
-* You can now generate codes of varying sizes, with varying degrees of ECC, and with varying border sizes
-* Image storage location is configurable to allow easier qrcode exposure to other modules
+* All options are available in the admin interface
+* Generate codes of varying sizes, with varying degrees of ECC, and with varying border sizes
+* Image storage location is configurable, allowing easier qrcode exposure to other modules
+* Code links are served using U-SRV, a secure system allowing greater integration
 * Auto-delete or preserve codes on plugin deactivation
-* Code links are served using a new secure system, U-SRV, that allows greater integration
 * Plenty of well documented, practical examples in the options page to help get started with integration
 * Updated and minimized md5.js
-* streamlined version of the QR Code generation library
-* almost half the total size in bytes
-  * This can be reduced in half yet again by disabling and deleting the PHP QR Code cache, which was left in for enhanced performance.This setting can be found on lnie 100 of `assets/phpqrcode.php`
+* Streamlined version of the QR Code generation library
+* Almost half the total size in bytes as its predecessor
+  * This can be reduced in half yet again by disabling and deleting the PHP QR Code cache, which was left in for enhanced performance. This setting can be found on lnie 100 of `assets/phpqrcode.php`
 * Select output image type
 * Include an optional logo file
   
 ## Installation
 1. Download this repo and extract the `iqrcodes` folder to `YOURLS/user/plugins/`
-2. Move `assets/srv.php` to `YOURLS/pages/`
-3. Set permissions
-4. Enable module, default config works fine, or visit IQRCodes page to fine tune.
-5. Have fun!
+2. Symlink `assets/srv.php` to `YOURLS/pages/srv.php`
+3. Symlink `assets/qrchk.php` to `YOURLS/pages/qrchk.php`
+4. Set permissions
+5. Enable module, default config works fine, or visit IQRCodes page to fine tune.
+6. Have fun!
 
 ## Credits
 [Inline QRcode](http://techlister.com/plugins-2/qrcode-plugin-for-yourls/354/) by Savoul Pelister is the base of this fork
@@ -41,9 +41,6 @@ This is an updated fork of [Inline QRCode](http://techlister.com/plugins-2/qrcod
 [PHP QR Code](http://phpqrcode.sourceforge.net/) by Dominik Dzienia (aka deltalab) generates the actual QR Codes
 
 [JavaScript MD5](https://blueimp.github.io/JavaScript-MD5/) by Sebastian Tschan (aka BlueImp) hashes the filenames in js
-
-#### DISCLAIMER:
-* This plugin is offered "as is", and may or may not work for you. Give it a try, and have fun!
 
 ===========================
 

--- a/iqrcodes/assets/iqrcodes.js
+++ b/iqrcodes/assets/iqrcodes.js
@@ -1,67 +1,49 @@
 function iqrcodes(url, site) {
-
 	if ( !( typeof url === 'undefined' ) || url ) {
 		var qrcimg = url;
 	}
 	else {
 		var shorturl = ( url == null ? $( '#copylink' ).val() : url );
-
 		var base_url = window.location.origin;
 
+		$.ajax({
+			type: "POST",
+				url: base_url + '/qrchk',
+				data:{action:'qrchk', data: shorturl}
+		});
+
 		function getCookie(name) {
-
 			var nameEQ = name + "=";
-
 			var ca = document.cookie.split(';');
-
 			for(var i=0;i < ca.length;i++) {
-
 				var c = ca[i];
-			
 				while (c.charAt(0)==' ') c = c.substring(1,c.length);
-
 				if (c.indexOf(nameEQ) == 0)
-
 					if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
-
 				}
-
 			return null;
-
 		}
     		var timestamp = getCookie('usrv_iqrcodes');
-
 		var key = md5(timestamp + 'iqrcodes');
-	
 		var fn = 'qrc_' + md5(shorturl) + '.png';
-	
 		var qrcimg = base_url + '/srv/?id=iqrcodes&key=' + key + '&fn=' + fn;
-
-		    console.log('key =' + key);
-		    console.log('cookie =' + timestamp);
-
 	}
-	
-	var insertimg = "<div id='qrcode' class='share'><h3>QR Code</h3><img id='myid' src='" + qrcimg + "' /></div>"
-	
+
+	var insertimg = "<div id='qrcode' class='share'><h3>QR Code</h3><img id='myid' src='" + qrcimg + "' /></div>";
 	if ( $( '#qrcode' ).length > 0 )
 		$( '#qrcode' ).remove( );
-	
 		$( "#shareboxes" ).append( insertimg );        // Append new elements
 		$( "div#qrcode img" ).css( "width", "100px" );
 		$( "div#qrcode img" ).css( "height", "100px" );
 }
-
 $(document).ready( function( ){
 	// Share button behavior
 	$( '.button_share' ).click( function( ){
 		iqrcodes( );
-	});
-				
+	});			
 	// Tab behavior on stats page
 	$('a[href="#stat_tab_share"]').click( function( ){
 		iqrcodes( );
-	});
-		  
+	});		  
 	iqrcodes();
 });

--- a/iqrcodes/assets/qrchk.php
+++ b/iqrcodes/assets/qrchk.php
@@ -1,0 +1,54 @@
+<?php
+/*
+	IQRCodes plugin for Yourls - URL Shortener ~ QRCode file check
+
+	This file is called when iqrcodes.js is loaded in order to verify
+	if a particular QRCode exists in the cache or not. If a short url 
+	was added to the database before IQRCodes was installed then there
+	will be no cached QR code, and it will need to be created.
+
+	This function checks the file system and then calls to generate
+	the QRCode if it is missing.
+
+	Copy, or make a link to this file in the pages directory like so:
+
+		YOURLS_DIR/pages/qrchk.php
+
+	in order for this function to operate properly.
+*/
+// No direct call
+if( !defined( 'YOURLS_ABSPATH' ) ) die();
+
+if( $_POST['action'] == 'qrchk' ) {
+
+	$data = $_POST['data'];
+	$shorturl = urldecode( $data );
+
+	iqrcodes_mkdir( $opt[0] );
+
+        $opt  = iqrcodes_get_opts();
+	$base = YOURLS_SITE;
+	$key = iqrcodes_key();
+	
+	iqrcodes_mkdir( $opt[0] );
+
+	$filename = '/qrc_' . md5($shorturl) . "." . $opt[5];
+	$filepath = $_SERVER['DOCUMENT_ROOT'] . '/' . $opt[0]. '/' . $filename;
+
+	$imgname  = $base . '/srv/?id=iqrcodes&key=' . $key . '&fn=' . $filename;
+
+	if ( !file_exists( $filepath ) && $shorturl == !null )
+		QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
+} else {
+	echo <<<HTML
+		<html>
+			<head>
+				<meta http-equiv="refresh" content="0;url=../">
+			</head>
+			<body>
+				YOURLS has nothing for you to see here.
+			</body>
+		</html>
+HTML;
+}
+?>

--- a/iqrcodes/plugin.php
+++ b/iqrcodes/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: IQRCodes
 Plugin URI: https://github.com/joshp23/YOURLS-IQRCodes
 Description: Integrated QR Codes
-Version: 1.1.4
+Version: 1.2.0
 Author: Josh Panter
 Author URI: https://unfettered.net
 */
@@ -339,32 +339,6 @@ function iqrcodes_key() {
 	$key = md5($now . 'iqrcodes');
 	return $key;
 }
-//Generate QR Code for shorturls generated before plugin installation. Currently you have to visit the "stats" page in order for this to work.
-yourls_add_filter( 'share_box_data', 'iqrcodes_sharebox' );
-function iqrcodes_sharebox( $data ) {
-
-	$shorturl = $data['shorturl'];
-        $opt  = iqrcodes_get_opts();
-
-	$base = YOURLS_SITE;
-	$key = iqrcodes_key();
-	
-	iqrcodes_mkdir( $opt[0] );
-
-	$filename = '/qrc_' . md5($shorturl) . "." . $opt[5];
- 	$filepath = $_SERVER['DOCUMENT_ROOT'] . '/' . $opt[0]. '/' . $filename;
-
-	$imgname  = $base . '/srv/?id=iqrcodes&key=' . $key . '&fn=' . $filename;
-
-	$data['qrcimg'] = $imgname;
-
-	if ( !file_exists( $filepath ) && $shorturl == !null )
-		QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
-
-	// required for direct call to yourls_add_new_link() which does not fire the javascript - lets do it manually
-	$data['qrimage'] = "<script>iqrcodes('$imgname', '$base');</script>";
-        return $data;
-}
 
 //Generate QRCode for new url added.
 yourls_add_filter( 'add_new_link', 'iqrcodes_add_url' );
@@ -394,7 +368,6 @@ function iqrcodes_add_url( $data ) {
 						
 	return $data;
 }
-
 
 //Generate new QRCode when the shorturl is edited.
 yourls_add_filter ( 'pre_edit_link' , 'iqrcodes_edit_url' );


### PR DESCRIPTION
Moves the function for checking qrcode existence for old links to a separate file that is called from iqrcodes.js via an ajax call. This solves the problem of qrcodes not being generated for old links in the admin interface when the share box is called. QR codes for old links are still generated when visiting the stats page for the old link.