### PR TITLE
1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is an updated fork of [Inline QRCode](http://techlister.com/plugins-2/qrcod
   * Border width
   * ECC level
   * Image file type
-  * Optional logo watermark
+  * Optional logo watermark (image preview, scale, location on QR Code)
   * Image cache location 
   * Auto-delete or preserve cache on plugin deactivation
 * Scan the entire database at once and generate QR Codes for any short url that is found to be missing one
@@ -47,7 +47,7 @@ This is an updated fork of [Inline QRCode](http://techlister.com/plugins-2/qrcod
 
 ===========================
 
-    Copyright (C) 2016 Josh Panter
+    Copyright (C) 2016 - 2017 Josh Panter
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
### FIXED:
-  Undefined Index: $imgTypeSelected['jpg']
-  Undefined Index: $imgTypeSelected['jpg']
-  Edited qrcodes going to wrong directory
-  If a new logo was a different type (png/jpg) than a previous logo, old logo to remained in cache. Fixed to delete old logo files on logo update.
### ALTERED:
-  Cleaned up ugly/bulky code
-  Moved logo storage to img cache
### ADDED:
-  Display selected logo in settings
-  Option to easily delete the logo file and reset logo settings to default