### PR TITLE
Fix broken yourls_plugin_url call

### DIFF
--- a/iqrcodes/plugin.php
+++ b/iqrcodes/plugin.php
@@ -346,7 +346,7 @@ function iqrcodes_js($context) {
 		echo "<script src=\"".$home."/js/infos.js?v=".YOURLS_VERSION."\" type=\"text/javascript\"></script>\n";
 	} elseif( !preg_match('/plugin.*/', $context[0] )) { 
 		$opt = iqrcodes_get_opts();
-		$loc = yourls_plugin_url(dirname(__FILE__));
+		$loc = yourls_plugin_url(basename(dirname(__FILE__)));
 		$file = dirname( __FILE__ )."/plugin.php";
 		$data = yourls_get_plugin_data( $file );
 		$v = $data['Version'];


### PR DESCRIPTION
YOURLS only needs the plugin name for yourls_plugin_url, not the
full path. Previously used 'dirname', which caused it to prepend
the entire absolute path (yikes) to the URL.

This was causing really broken and bizarre URLs, causing QR codes
to not be displayed.