### PR TITLE
Fix the broken "yourls_plugin_url" call

### DIFF
--- a/iqrcodes/plugin.php
+++ b/iqrcodes/plugin.php
@@ -346,7 +346,7 @@ function iqrcodes_js($context) {
 		echo "<script src=\"".$home."/js/infos.js?v=".YOURLS_VERSION."\" type=\"text/javascript\"></script>\n";
 	} elseif( !preg_match('/plugin.*/', $context[0] )) { 
 		$opt = iqrcodes_get_opts();
-		$loc = yourls_plugin_url(dirname(__FILE__));
+		$loc = yourls_plugin_url(basename(dirname(__FILE__)));
 		$file = dirname( __FILE__ )."/plugin.php";
 		$data = yourls_get_plugin_data( $file );
 		$v = $data['Version'];


### PR DESCRIPTION
QRs were not displaying; server was showing a ton of 404 and 403 errors.

plugin.php was passing "dirname" for the plugin.php to yourls_plugin_call(), which was creating URLs that looked like this: `<script src="https://_____.sh/user/plugins/home/jmedlock/www/site1/github-plugins-YOURLS/YOURLS-IQRCodes/iqrcodes/assets/md5.min.js?v=2.1.2" type="text/javascript"></script>`.

Added a basename so it only passed the directory name housing the plugin.php, and URLs are now correct. QR's and other assets are now loaded and shown properly.