### PR TITLE
Make sharebox QR code respect file extension option, fix SVG generation

### DIFF
--- a/iqrcodes/assets/iqrcodes.js
+++ b/iqrcodes/assets/iqrcodes.js
@@ -11,25 +11,9 @@ function iqrcodes(url, site) {
 			url: base_url + '/qrchk',
 			data:{action:'qrchk', data: shorturl}
 		});
-
-		function getCookie(name) {
-			var nameEQ = name + "=";
-			var ca = document.cookie.split(';');
-			for(var i=0;i < ca.length;i++) {
-				var c = ca[i];
-				while (c.charAt(0)==' ') c = c.substring(1,c.length);
-				if (c.indexOf(nameEQ) == 0)
-					if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
-				}
-			return null;
-		}
-    		var timestamp = getCookie('usrv_iqrcodes');
-		var key = md5(timestamp + 'iqrcodes');
-		var fn = 'qrc_' + md5(shorturl) + '.png';
-		var qrcimg = base_url + '/srv/?id=iqrcodes&key=' + key + '&fn=' + fn;
 	}
 
-	var insertimg = "<div id='qrcode' class='share'><h3>QR Code</h3><img id='myid' src='" + qrcimg + "' /></div>";
+	var insertimg = "<div id='qrcode' class='share'><h3>QR Code</h3><img id='myid' src='" + shorturl + ".qr" + "' /></div>";
 	if ( $( '#qrcode' ).length > 0 )
 		$( '#qrcode' ).remove( );
 		$( "#shareboxes" ).append( insertimg );        // Append new elements

--- a/iqrcodes/assets/iqrcodes.js
+++ b/iqrcodes/assets/iqrcodes.js
@@ -1,11 +1,10 @@
 function iqrcodes(url, site) {
 	if ( !( typeof url === 'undefined' ) || url ) {
-		var qrcimg = url;
+		var shorturl = url;
 	}
 	else {
 		var shorturl = ( url == null ? $( '#copylink' ).val() : url );
 		var base_url = window.location.origin;
-
 		$.ajax({
 			type: "POST",
 			url: base_url + '/qrchk',
@@ -14,11 +13,12 @@ function iqrcodes(url, site) {
 	}
 
 	var insertimg = "<div id='qrcode' class='share'><h3>QR Code</h3><img id='myid' src='" + shorturl + ".qr" + "' /></div>";
-	if ( $( '#qrcode' ).length > 0 )
+	if ( $( '#qrcode' ).length > 0 ) {
 		$( '#qrcode' ).remove( );
-		$( "#shareboxes" ).append( insertimg );        // Append new elements
-		$( "div#qrcode img" ).css( "width", "100px" );
-		$( "div#qrcode img" ).css( "height", "100px" );
+	}		
+	$( "#shareboxes" ).append( insertimg );        // Append new elements
+	$( "div#qrcode img" ).css( "width", "100px" );
+	$( "div#qrcode img" ).css( "height", "100px" );
 }
 $(document).ready( function( ){
 	// Share button behavior
@@ -31,4 +31,3 @@ $(document).ready( function( ){
 	});		  
 	iqrcodes();
 });
-

--- a/iqrcodes/assets/qrchk.php
+++ b/iqrcodes/assets/qrchk.php
@@ -30,7 +30,11 @@ if( ($_POST['action'] == 'qrchk') && isset($_POST['data']) && ($_POST['data'] !=
 
 	if ( !file_exists( $filepath ) && $shorturl == !null ) {
 		iqrcodes_mkdir( $opt[10] );
-		QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
+		if ( $opt[5] === 'svg' ) {
+			QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3], 0xFFFFFF, 0x000000);
+		} else {
+			QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
+		}
 	}
 } else {
 	echo <<<HTML

--- a/iqrcodes/plugin.php
+++ b/iqrcodes/plugin.php
@@ -478,30 +478,26 @@ function iqrcodes_key() {
 //Generate QRCode for new url added.
 yourls_add_filter( 'add_new_link', 'iqrcodes_add_url' );
 function iqrcodes_add_url( $data ) {
-            
     $base = YOURLS_SITE;
     $key  = iqrcodes_key();
     $opt  = iqrcodes_get_opts();
-        
 	$shorturl = $data['shorturl'];
-	
 	iqrcodes_mkdir( $opt[10] );
-
 	$filename = 'qrc_'. md5($shorturl) . "." . $opt[5];
 	$filepath = $opt[10]. '/' . $filename;
+	if ($opt[5] === 'svg') {
+		QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3], 0xFFFFFF, 0x000000 );
+	} else {
+		QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
+	}
 	
-	$imgname  = $base . '/srv/?id=iqrcodes&key=' . $key . '&fn=' . $filename;
-	
-	$data['qrcimg'] = $imgname;
-	
-	QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
 	
 	if( !yourls_is_API() ) {
 		// required for direct call to yourls_add_new_link() which does not fire the javascript - lets do it manually
 		if ( isset( $data['html'] ) ) { 
-			$data['html'] .= "<script>iqrcodes( '$imgname' , '$base' );</script>";
+			$data['html'] .= "<script>iqrcodes( '$shorturl' , '$base' );</script>";
 		} else {
-			$data['html'] = "<script>iqrcodes( '$imgname' , '$base' );</script>";
+			$data['html'] = "<script>iqrcodes( '$shorturl' , '$base' );</script>";
 		}
 	
 	}			
@@ -512,29 +508,22 @@ function iqrcodes_add_url( $data ) {
 //Generate new QRCode when the shorturl is edited.
 yourls_add_filter ( 'pre_edit_link' , 'iqrcodes_edit_url' );
 function iqrcodes_edit_url( $data ) {
-		
 	$oldkeyword = $data[1];
 	$newkeyword = $data[2];
-	
 	$opt  = iqrcodes_get_opts();
 	iqrcodes_mkdir( $opt[10] );
-	
 	$base = YOURLS_SITE;
-
 	$oldfilepath = $opt[10] . '/' . 'qrc_' . md5($base . '/' . $oldkeyword) . "." . $opt[5];
-	
 	if ( file_exists( $oldfilepath ))
 		unlink( $oldfilepath );
-	
 	$newfilename = 'qrc_' . md5($base . '/' . $newkeyword) . "." . $opt[5];
 	$newfilepath = $opt[10] . '/' . $newfilename;
+	if ( $opt[5] === 'svg' ) {
+		QRcode::{$opt[5]}( $base . '/' . $newkeyword, $newfilepath,  $opt[1], $opt[2], $opt[3], 0xFFFFFF, 0x000000 );
+	} else {
+		QRcode::{$opt[5]}( $base . '/' . $newkeyword, $newfilepath,  $opt[1], $opt[2], $opt[3] );
+	}
 	
-	$key  = iqrcodes_key();
-	$imgname  = $base . '/srv/?id=iqrcodes&key=' . $key . '&fn=' . $newfilename;
-
-	$data['qrcimg'] = $imgname;
-	
-	QRcode::{$opt[5]}( $base . '/' . $newkeyword, $newfilepath,  $opt[1], $opt[2], $opt[3] );
 	
 	return $data;
 }
@@ -544,7 +533,7 @@ yourls_add_action ( 'delete_link' , 'iqrcodes_delete_url' );
 function iqrcodes_delete_url( $data ) {
 
 	$keyword = $data[0];
-       $opt  = iqrcodes_get_opts();
+    $opt  = iqrcodes_get_opts();
 	
 	$filename = 'qrc_' . md5(YOURLS_SITE . '/' . $keyword) . "." . $opt[5];
 	$filepath = $opt[10]. '/' . $filename;
@@ -660,7 +649,12 @@ function iqrcodes_mass_chk() {
 			$filename = '/qrc_' . md5($shorturl) . "." . $opt[5];
 			$filepath = $opt[10]. '/' . $filename;
 			if ( !file_exists( $filepath ) && $shorturl == !null ) {
-				QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
+				if ( $opt[5] === 'svg' ) {
+					QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3], 0xFFFFFF, 0x000000 );
+				} else {
+					QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
+				}
+				
 				$i++;
 			}
 		}
@@ -692,10 +686,13 @@ function iqrcode_dot_qr( $request ) {
 
 					$filename = 'qrc_'. md5($shorturl) . "." . $opt[5];
 					$filepath = $opt[10]. '/' . $filename;
-
 					if ( !file_exists( $filepath ) ) {
-
-						QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
+						if ( $opt[5] === 'svg' ) {
+							QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3], 0xFFFFFF, 0x000000 );
+						} else {
+							QRcode::{$opt[5]}( $shorturl, $filepath, $opt[1], $opt[2], $opt[3] );
+						}
+ 						
 
 					}
 


### PR DESCRIPTION
This PR fixes two issues: #33, where SVG QR generation is broken and throws an error, and #34, where the QR code in the sharebox was hardcoded to `.png` no matter the options set in IQRCodes settings in YOURLS.

#33 was caused due to `QRVector::svg` requiring (in addition to the already given parameters) a background color and foreground color. Work can be done to make this customisable for svg, but this PR hardcodes it to black on white (as per the usual).

#34 is caused due to the `href` in the image element being hardcoded to a .png. This is fixed by changing the href to the `<shortlink>.qr` implementation based in PHP that _does_  respect the file format option.

This PR was tested on a YOURLS 1.7.6 installation.